### PR TITLE
Update into audit feature

### DIFF
--- a/core.sln
+++ b/core.sln
@@ -84,7 +84,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetHacksPack.Database.Exten
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestNetHacksPackLogging", "..\testes\TestNetHacksPackLogging\TestNetHacksPackLogging.csproj", "{E443A4F7-008C-495F-8455-CEDC534C7089}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetHacksPack.Data.Linq.EF", "src\NetHacksPack.Data.Linq.EF\NetHacksPack.Data.Linq.EF.csproj", "{A26EC6A4-59C4-48A4-8BA3-E7397A10F5F5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetHacksPack.Data.Linq.EF", "src\NetHacksPack.Data.Linq.EF\NetHacksPack.Data.Linq.EF.csproj", "{A26EC6A4-59C4-48A4-8BA3-E7397A10F5F5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Extensions", "Extensions", "{9A075BFB-5200-4FE6-9288-B9E86F3258B3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -234,6 +236,7 @@ Global
 		{0EE1834D-EC8A-452F-B076-6893DEC176E4} = {87524CAB-9F81-4BF7-8D45-B6925DC89DE1}
 		{B2A7E318-6821-4573-848C-F9552D3D3828} = {87524CAB-9F81-4BF7-8D45-B6925DC89DE1}
 		{A26EC6A4-59C4-48A4-8BA3-E7397A10F5F5} = {E9247C3F-C3E9-4178-A243-CBFEC765AA5F}
+		{9A075BFB-5200-4FE6-9288-B9E86F3258B3} = {E9247C3F-C3E9-4178-A243-CBFEC765AA5F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DFFE86AD-D078-4C1A-85F2-4C053F66D6A7}

--- a/src/NetHacksPack.Database.Events/TrackedEntity.cs
+++ b/src/NetHacksPack.Database.Events/TrackedEntity.cs
@@ -11,9 +11,9 @@ namespace NetHacksPack.Database.Events
         {
             this.EntityEntries = entityEntries;
             this.OriginalValues = entityEntries.GroupBy(b => b.OriginalValues.EntityType.GetTableName()).ToDictionary(
-                s => s.Key,
-                s => s.Select(item => new Tracker(item.Metadata, item, item.OriginalValues.Clone())).ToList().AsEnumerable()
-             );
+              s => s.Key,
+              s => s.Select(item => new Tracker(item.Metadata, item, item.OriginalValues.Properties.ToDictionary(p => p.Name, p => item.GetDatabaseValues()?.GetValue<object>(p)?.ToString()))).ToList().AsEnumerable()
+           );
         }
 
         public IEnumerable<EntityEntry> EntityEntries { get; }

--- a/src/NetHacksPack.Database.Events/Tracker.cs
+++ b/src/NetHacksPack.Database.Events/Tracker.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
+using System.Collections.Generic;
 
 namespace NetHacksPack.Database.Events
 {
     public struct Tracker
     {
-        public Tracker(IEntityType entityType, EntityEntry entry, PropertyValues propertyValues) : this()
+        public Tracker(IEntityType entityType, EntityEntry entry, Dictionary<string, string> propertyValues) : this()
         {
             this.Metadata = entityType;
             this.Entry = entry;
@@ -14,6 +15,6 @@ namespace NetHacksPack.Database.Events
 
         public IEntityType Metadata { get; set; }
         public EntityEntry Entry { get; set; }
-        public PropertyValues OriginalValues { get; set; }
+        public Dictionary<string, string> OriginalValues { get; set; }
     }
 }

--- a/src/NetHacksPack.Database.Extension.EF/DbContext.cs
+++ b/src/NetHacksPack.Database.Extension.EF/DbContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using NetHacksPack.Core;
@@ -42,6 +43,26 @@ namespace NetHacksPack.Database.Extension.EF
             this.mediatorHandler?.SendCommand(new ApplyConfigurationsToContextCommand(modelBuilder));
             this.ConfigureModels(modelBuilder);
             base.OnModelCreating(modelBuilder);
+        }
+
+        public override EntityEntry<TEntity> Update<TEntity>(TEntity entity)
+        {
+            if (this.Entry(entity).State == EntityState.Detached)
+            {
+                this.Attach(entity);
+                this.ChangeTracker.DetectChanges();
+            }
+            return base.Update(entity);
+        }
+
+        public override EntityEntry Update(object entity)
+        {
+            if (this.Entry(entity).State == EntityState.Detached)
+            {
+                this.Attach(entity);
+                this.ChangeTracker.DetectChanges();
+            }
+            return base.Update(entity);
         }
 
         public override int SaveChanges(bool acceptAllChangesOnSuccess)

--- a/src/NetHacksPack.Database.Extension.EF/Infrastructure/ColumnCommandDefinition.cs
+++ b/src/NetHacksPack.Database.Extension.EF/Infrastructure/ColumnCommandDefinition.cs
@@ -1,0 +1,15 @@
+﻿namespace NetHacksPack.Database.Extension.EF.Infrastructure
+{
+    public abstract class ColumnCommandDefinition : CommandDefinition
+    {
+        public abstract ColumnCommandDefinition Name(string name);
+
+        public abstract ColumnCommandDefinition IsNull();
+
+        public abstract ColumnCommandDefinition IsNotNull();
+
+        public abstract ColumnCommandDefinition HasType(ColumnTypeCommandDefinition type);
+
+        public abstract ColumnCommandDefinition PrimaryKey();
+    }
+}

--- a/src/NetHacksPack.Database.Extension.EF/Infrastructure/ColumnTypeCommandDefinition.cs
+++ b/src/NetHacksPack.Database.Extension.EF/Infrastructure/ColumnTypeCommandDefinition.cs
@@ -1,0 +1,7 @@
+﻿namespace NetHacksPack.Database.Extension.EF.Infrastructure
+{
+    public abstract class ColumnTypeCommandDefinition : CommandDefinition
+    {
+
+    }
+}

--- a/src/NetHacksPack.Database.Extension.EF/Infrastructure/CommandDefinition.cs
+++ b/src/NetHacksPack.Database.Extension.EF/Infrastructure/CommandDefinition.cs
@@ -1,0 +1,12 @@
+﻿namespace NetHacksPack.Database.Extension.EF.Infrastructure
+{
+    public abstract class CommandDefinition
+    {
+        public static implicit operator string(CommandDefinition commandDefinition)
+        {
+            return commandDefinition.CreateCommand();
+        }
+
+        public abstract string CreateCommand();
+    }
+}

--- a/src/NetHacksPack.Database.Extension.EF/Infrastructure/CreateTableCommandDefinition.cs
+++ b/src/NetHacksPack.Database.Extension.EF/Infrastructure/CreateTableCommandDefinition.cs
@@ -1,0 +1,11 @@
+﻿namespace NetHacksPack.Database.Extension.EF.Infrastructure
+{
+    public abstract class CreateTableCommandDefinition : CommandDefinition
+    {
+        public abstract CreateTableCommandDefinition Schema(string name);
+
+        public abstract CreateTableCommandDefinition Name(string name);
+
+        public abstract CreateTableCommandDefinition Columns(ColumnCommandDefinition[] columns);
+    }
+}

--- a/src/NetHacksPack.Database.Extension.EF/Infrastructure/Exceptions/InvalidSintaxException.cs
+++ b/src/NetHacksPack.Database.Extension.EF/Infrastructure/Exceptions/InvalidSintaxException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NetHacksPack.Database.Extension.EF.Infrastructure.Exceptions
+{
+    public class InvalidSintaxException : Exception
+    {
+        public InvalidSintaxException(string message)
+            : base("Invalid sintax: " + message)
+        {
+
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extension.EF/Infrastructure/IDatabaseCommandGenerator.cs
+++ b/src/NetHacksPack.Database.Extension.EF/Infrastructure/IDatabaseCommandGenerator.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NetHacksPack.Database.Extension.EF.Infrastructure
+{
+    public interface IDatabaseCommandGenerator
+    {
+        CreateTableCommandDefinition GetCreateTableScript();
+
+        string GetInsertScript();
+
+        ColumnTypeCommandDefinition GetVarcharColumn(int lenght);
+
+        ColumnTypeCommandDefinition GetDateTimeColumn();
+
+        ColumnTypeCommandDefinition GetJsonColumn();
+
+        ColumnCommandDefinition CreateColumn();
+
+        ColumnTypeCommandDefinition GetUniqueIdentifierColumn();
+    }
+}

--- a/src/NetHacksPack.Database.Extension.EF/Infrastructure/IHistoricalRepository.cs
+++ b/src/NetHacksPack.Database.Extension.EF/Infrastructure/IHistoricalRepository.cs
@@ -1,0 +1,9 @@
+﻿namespace NetHacksPack.Database.Extension.EF.Infrastructure
+{
+    public interface IHistoricalRepository
+    {
+        bool HasEventLogTable(string migrationId);
+
+        string GetInsertScript(string key, string value);
+    }
+}

--- a/src/NetHacksPack.Database.Extension.EFCore.Logging/DependencyInjection/DatabaseInfrastructureDependenciesInjector.cs
+++ b/src/NetHacksPack.Database.Extension.EFCore.Logging/DependencyInjection/DatabaseInfrastructureDependenciesInjector.cs
@@ -4,6 +4,7 @@ using NetHacksPack.Database.Extension.EFCore.Logging.Configuration;
 using System.Collections.Generic;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using NetHacksPack.Database.Extension.EFCore.Logging.Providers;
 
 namespace NetHacksPack.Database.Extension.EFCore.Logging.DependencyInjection
 {
@@ -22,14 +23,16 @@ namespace NetHacksPack.Database.Extension.EFCore.Logging.DependencyInjection
             return services;
         }
 
-        public static LoggerExtensionBuilder AddLoggingExtensionForEF<TDbContext>(this IServiceCollection services, UserProvider userProvider, EventLogsConfigurationProvider eventLogsConfigurationProvider)
+        public static LoggerExtensionBuilder AddLoggingExtensionForEF<TDbContext>(this IServiceCollection services, string auditTableName, UserProvider userProvider, EventLogsConfigurationProvider eventLogsConfigurationProvider)
             where TDbContext : DbContext
         {
             var blackList = new List<IgnoredEntity>();
             services.AddScoped<IRequestHandler<ApplyConfigurationsToContextCommand, bool>, ContextConfigurationHandler>();
+            services.AddSingleton<AuditTableNameProvider>(() => auditTableName);
             services.AddSingleton(userProvider);
+            services.AddSingleton(blackList);
             services.AddSingleton(eventLogsConfigurationProvider);
-            services.AddSingleton(blackList); 
+            services.AddScoped<IDatabaseAuditProvider, DatabaseAuditProvider>();
             services.DisableAllLogOn<EventLog>();
             services.AddScoped<DbContextProvider>((serviceProvider) =>
             {

--- a/src/NetHacksPack.Database.Extension.EFCore.Logging/EventLog.cs
+++ b/src/NetHacksPack.Database.Extension.EFCore.Logging/EventLog.cs
@@ -4,6 +4,8 @@ using System.Text;
 
 namespace NetHacksPack.Database.Extension.EFCore.Logging
 {
+    public delegate string AuditTableNameProvider();
+
     public class EventLog
     {
         public Guid Id { get; set; }

--- a/src/NetHacksPack.Database.Extension.EFCore.Logging/Infrastructure/HistoricalRepository.cs
+++ b/src/NetHacksPack.Database.Extension.EFCore.Logging/Infrastructure/HistoricalRepository.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore;
+using NetHacksPack.Database.Extension.EF.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NetHacksPack.Database.Extension.EFCore.Logging.Infrastructure
+{
+    class HistoricalRepository : IHistoricalRepository
+    {
+        private readonly DbContext dbContext;
+        private readonly IDatabaseCommandGenerator databaseCommandGenerator;
+
+        public HistoricalRepository(DbContext dbContext, IDatabaseCommandGenerator databaseCommandGenerator)
+        {
+            this.dbContext = dbContext;
+            this.databaseCommandGenerator = databaseCommandGenerator;
+        }
+
+        public string GetInsertScript(string key, string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasEventLogTable(string migrationId)
+        {
+            return this.dbContext.Database.GetAppliedMigrations().Any(a => a == migrationId);
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extension.EFCore.Logging/Infrastructure/IHistoricalRepository.cs
+++ b/src/NetHacksPack.Database.Extension.EFCore.Logging/Infrastructure/IHistoricalRepository.cs
@@ -1,0 +1,9 @@
+﻿namespace NetHacksPack.Database.Extension.EFCore.Logging.Infrastructure
+{
+    interface IHistoricalRepository2
+    {
+        bool HasMisgration(string migrationId);
+
+        string GetInsertScript(string key, string value);
+    }
+}

--- a/src/NetHacksPack.Database.Extension.EFCore.Logging/LogEventHandler.cs
+++ b/src/NetHacksPack.Database.Extension.EFCore.Logging/LogEventHandler.cs
@@ -1,14 +1,12 @@
 ﻿using MediatR;
 using Microsoft.EntityFrameworkCore;
 using NetHacksPack.Database.Events;
-using NetHacksPack.Database.Extension.EF;
 using NetHacksPack.Database.Extension.EFCore.Logging.DependencyInjection;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Principal;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -42,12 +40,12 @@ namespace NetHacksPack.Database.Extension.EFCore.Logging
 
             foreach (var item in notification.Data.OriginalValues.SelectMany(k => k.Value.Select(s => new { Value = s, k.Key })))
             {
-                if (IsOnBlackList(notification.GetType().Name, item.Value.OriginalValues.EntityType.ShortName()))
+                if (IsOnBlackList(notification.GetType().Name, item.Value.Metadata.ShortName()))
                     continue;
                 var f = item.Value.Entry;
                 var primaryKey = item.Value.Metadata.FindPrimaryKey();
                 var primaryKeys = primaryKey.Properties.ToDictionary(p => p.Name, p => f.Property(p.Name).CurrentValue?.ToString());
-                var originalItems = item.Value.OriginalValues.Properties.ToDictionary(p => p.Name, p => item.Value.OriginalValues.GetValue<object>(p)?.ToString());
+                var originalItems = item.Value.OriginalValues;
                 var currentValues = item.Value.Entry.CurrentValues.Properties.ToDictionary(p => p.Name, p => f.Property(p.Name).OriginalValue?.ToString());
                 var log = new EventLog();
                 log.CreatedAt = DateTime.Now;
@@ -71,12 +69,12 @@ namespace NetHacksPack.Database.Extension.EFCore.Logging
             foreach (var item in notification.Data.OriginalValues.SelectMany(k => k.Value.Select(s => new { Value = s, k.Key })))
             {
 
-                if (IsOnBlackList(notification.GetType().Name, item.Value.OriginalValues.EntityType.ShortName()))
+                if (IsOnBlackList(notification.GetType().Name, item.Value.Metadata.ShortName()))
                     continue;
                 var f = item.Value.Entry;
                 var primaryKey = item.Value.Metadata.FindPrimaryKey();
                 var primaryKeys = primaryKey.Properties.ToDictionary(p => p.Name, p => f.Property(p.Name).CurrentValue?.ToString());
-                var originalItems = item.Value.OriginalValues.Properties.ToDictionary(p => p.Name, p => item.Value.OriginalValues.GetValue<object>(p)?.ToString());
+                var originalItems = item.Value.OriginalValues;
                 var currentValues = item.Value.Entry.CurrentValues.Properties.ToDictionary(p => p.Name, p => f.Property(p.Name).OriginalValue?.ToString());
                 var log = new EventLog();
                 log.CreatedAt = DateTime.Now;
@@ -94,12 +92,12 @@ namespace NetHacksPack.Database.Extension.EFCore.Logging
         {
             foreach (var item in notification.Data.OriginalValues.SelectMany(k => k.Value.Select(s => new { Value = s, k.Key })))
             {
-                if (IsOnBlackList(notification.GetType().Name, item.Value.OriginalValues.EntityType.ShortName()))
+                if (IsOnBlackList(notification.GetType().Name, item.Value.Metadata.ShortName()))
                     continue;
                 var f = item.Value.Entry;
                 var primaryKey = item.Value.Metadata.FindPrimaryKey();
                 var primaryKeys = primaryKey.Properties.ToDictionary(p => p.Name, p => f.Property(p.Name).CurrentValue?.ToString());
-                var originalItems = item.Value.OriginalValues.Properties.ToDictionary(p => p.Name, p => item.Value.OriginalValues.GetValue<object>(p)?.ToString());
+                var originalItems = item.Value.OriginalValues;
                 var currentValues = item.Value.Entry.CurrentValues.Properties.ToDictionary(p => p.Name, p => f.Property(p.Name).OriginalValue?.ToString());
                 var log = new EventLog();
                 log.CreatedAt = DateTime.Now;

--- a/src/NetHacksPack.Database.Extension.EFCore.Logging/Providers/DatabaseAuditProvider.cs
+++ b/src/NetHacksPack.Database.Extension.EFCore.Logging/Providers/DatabaseAuditProvider.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore;
+using NetHacksPack.Database.Extension.EF.Infrastructure;
+using NetHacksPack.Database.Extension.EFCore.Logging.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NetHacksPack.Database.Extension.EFCore.Logging.Providers
+{
+    class DatabaseAuditProvider : IDatabaseAuditProvider
+    {
+        const string MIGRATION = "NetHacksPack.Database.Extension.EFCore.Logging.Providers";
+
+        private readonly DbContext dbContext;
+        private readonly IHistoricalRepository historicalRepository;
+        private readonly IDatabaseCommandGenerator databaseCommandGenerator;
+        private readonly SchemmaNameProvider schemmaNameProvider;
+        private readonly AuditTableNameProvider auditTableName;
+
+        public DatabaseAuditProvider(IServiceProvider serviceProvider, DbContextProvider dbContext, IHistoricalRepository historicalRepository, IDatabaseCommandGenerator databaseCommandGenerator, SchemmaNameProvider schemmaNameProvider, AuditTableNameProvider auditTableName)
+        {
+            this.dbContext = dbContext(serviceProvider);
+            this.historicalRepository = historicalRepository;
+            this.databaseCommandGenerator = databaseCommandGenerator;
+            this.schemmaNameProvider = schemmaNameProvider;
+            this.auditTableName = auditTableName;
+        }
+
+        public void Initialize()
+        {
+            var auditTableName = this.auditTableName();
+            if (historicalRepository.HasEventLogTable(auditTableName))
+                return;
+            this.dbContext.Database.GetAppliedMigrations().ToList();
+            var table = this.databaseCommandGenerator.GetCreateTableScript();
+            table.Name(auditTableName);
+            table.Schema(schemmaNameProvider());
+            table.Columns(this.GetColumnStructure());
+            var createLogTableScript = table.CreateCommand();
+            this.dbContext.Database.ExecuteSqlRaw(createLogTableScript);
+        }
+
+        private ColumnCommandDefinition[] GetColumnStructure()
+        {
+            List<ColumnCommandDefinition> columns = new List<ColumnCommandDefinition>();
+            columns.Add(this.databaseCommandGenerator.CreateColumn().Name("Id").HasType(this.databaseCommandGenerator.GetUniqueIdentifierColumn()).PrimaryKey());
+            columns.Add(this.databaseCommandGenerator.CreateColumn().Name("CreatedAt").HasType(this.databaseCommandGenerator.GetDateTimeColumn()));
+            columns.Add(this.databaseCommandGenerator.CreateColumn().Name("EntityType").HasType(this.databaseCommandGenerator.GetVarcharColumn(100)));
+            columns.Add(this.databaseCommandGenerator.CreateColumn().Name("EventUser").HasType(this.databaseCommandGenerator.GetVarcharColumn(100)));
+            columns.Add(this.databaseCommandGenerator.CreateColumn().Name("EventType").HasType(this.databaseCommandGenerator.GetVarcharColumn(50)));
+            columns.Add(this.databaseCommandGenerator.CreateColumn().Name("DataKeysValues").HasType(this.databaseCommandGenerator.GetJsonColumn()));
+            columns.Add(this.databaseCommandGenerator.CreateColumn().Name("OriginalValues").HasType(this.databaseCommandGenerator.GetJsonColumn()));
+            return columns.ToArray();
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extension.EFCore.Logging/Providers/IDatabaseAuditProvider.cs
+++ b/src/NetHacksPack.Database.Extension.EFCore.Logging/Providers/IDatabaseAuditProvider.cs
@@ -1,0 +1,11 @@
+﻿using NetHacksPack.Database.Extension.EFCore.Logging.Infrastructure;
+
+namespace NetHacksPack.Database.Extension.EFCore.Logging.Providers
+{
+    public delegate string SchemmaNameProvider();
+
+    public interface IDatabaseAuditProvider
+    {
+        void Initialize();
+    }
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Configuration/PostgreSqlEventLogConfiguration.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Configuration/PostgreSqlEventLogConfiguration.cs
@@ -7,9 +7,16 @@ namespace NetHacksPack.Database.Extensions.EFCore.Logging.PostgreSql.Configurati
 {
     internal class PostgreSqlEventLogConfiguration : EventsLogsConfiguration
     {
+        private readonly string tableName;
+
+        public PostgreSqlEventLogConfiguration(string tableName)
+        {
+            this.tableName = tableName;
+        }
+
         public override void Configure(EntityTypeBuilder<EventLog> builder)
         {
-            builder.ToTable("EventsLogs");
+            builder.ToTable(tableName);
 
             builder.HasKey(p => p.Id);
 

--- a/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/DependencyInjection/DatabaseInfrastructureDependenciesInjector.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/DependencyInjection/DatabaseInfrastructureDependenciesInjector.cs
@@ -1,18 +1,28 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using NetHacksPack.Database.Extension.EF.Infrastructure;
 using NetHacksPack.Database.Extension.EFCore.Logging.DependencyInjection;
+using NetHacksPack.Database.Extension.EFCore.Logging.Providers;
 using NetHacksPack.Database.Extensions.EFCore.Logging.PostgreSql.Configuration;
+using NetHacksPack.Database.Extensions.EFCore.Logging.PostgreSql.Infrastructure;
 
 namespace NetHacksPack.Database.Extensions.EFCore.Logging.PostgreSql.DependencyInjection
 {
     public static class DatabaseInfrastructureDependenciesInjector
     {
-        public static LoggerExtensionBuilder AddLoggingExtensionForEFPostgreSql<TDbContext>(this IServiceCollection services, UserProvider userProvider)
+        public static LoggerExtensionBuilder AddLoggingExtensionForEFPostgreSql<TDbContext>(this IServiceCollection services, string tableName, UserProvider userProvider, string migrationTableName, string schemma = null)
             where TDbContext : DbContext
         {
-            return services.AddLoggingExtensionForEF<TDbContext>(userProvider, (services) =>
+            services.AddScoped<IHistoricalRepository, PostgreSqlHistoricalRepository>();
+            services.AddScoped<IDatabaseCommandGenerator, PostgreSqlServerCommandGenerator>();
+            services.AddSingleton<SchemmaNameProvider>(() => (schemma?.Length > 0 ? schemma : string.Empty));
+            services.AddSingleton<MigrationTableNameProvider>(() =>
             {
-                return new PostgreSqlEventLogConfiguration();
+                return (schemma?.Length > 0 ? "\"" + schemma + "\"." : string.Empty) + "\"" + migrationTableName + "\"";
+            });
+            return services.AddLoggingExtensionForEF<TDbContext>(tableName, userProvider, (services) =>
+            {
+                return new PostgreSqlEventLogConfiguration(tableName);
             });
         }
     }

--- a/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlColumnCommandDefinition.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlColumnCommandDefinition.cs
@@ -1,0 +1,64 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+using NetHacksPack.Database.Extension.EF.Infrastructure.Exceptions;
+using System.Collections.Generic;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.PostgreSql.Infrastructure
+{
+    class PostgreSqlColumnCommandDefinition : ColumnCommandDefinition
+    {
+        private Dictionary<string, string> definitions = new Dictionary<string, string>(3);
+
+        private void SetData(string key, string value)
+        {
+            if (!definitions.ContainsKey(key))
+                definitions.Add(key, string.Empty);
+            definitions[key] = value;
+        }
+
+        public override ColumnCommandDefinition HasType(ColumnTypeCommandDefinition type)
+        {
+            this.SetData("TYPE", type.CreateCommand());
+            return this;
+        }
+
+        public override ColumnCommandDefinition IsNotNull()
+        {
+            this.SetData("NULL", "IS NOT NULL");
+            return this;
+        }
+
+        public override ColumnCommandDefinition IsNull()
+        {
+            this.SetData("NULL", "IS NULL");
+            return this;
+        }
+
+        public override ColumnCommandDefinition Name(string name)
+        {
+            this.SetData("NAME", "\"" + name + "\"");
+            return this;
+        }
+
+        public override ColumnCommandDefinition PrimaryKey()
+        {
+            SetData("PK", "NOT NULL PRIMARY KEY");
+            return this;
+        }
+
+        public override string CreateCommand()
+        {
+            if (!this.definitions.ContainsKey("NAME"))
+                throw new InvalidSintaxException("invalid column name, a column name must be informed to create a column");
+            if(!this.definitions.ContainsKey("TYPE"))
+                throw new InvalidSintaxException("invalid column type, a column type must be informed to create a column");
+            return string.Join(" ", SafeGetValue("NAME"), SafeGetValue("TYPE"), SafeGetValue("NULL"), SafeGetValue("PK")).TrimEnd();
+        }
+
+        private string SafeGetValue(string key)
+        {
+            if (!this.definitions.ContainsKey(key))
+                return string.Empty;
+            return this.definitions[key] ?? string.Empty;
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlCreateTableCommandDefinition.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlCreateTableCommandDefinition.cs
@@ -1,0 +1,58 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+using NetHacksPack.Database.Extension.EF.Infrastructure.Exceptions;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.PostgreSql.Infrastructure
+{
+    class PostgreSqlCreateTableCommandDefinition : CreateTableCommandDefinition
+    {
+        private Dictionary<string, string> definitions = new Dictionary<string, string>(3);
+        private ColumnCommandDefinition[] columns = null;
+
+        private void SetData(string key, string value)
+        {
+            if (!definitions.ContainsKey(key))
+                definitions.Add(key, string.Empty);
+            definitions[key] = value;
+        }
+
+        public override string CreateCommand()
+        {
+            if (!this.definitions.ContainsKey("NAME"))
+                throw new InvalidSintaxException("invalid table name, a table name must be informed to create a table");
+            if(columns == null || columns.Length == 0)
+                throw new InvalidSintaxException("invalid columns definitions, a set of columns must be informed to create a table");
+
+            var script = "CREATE TABLE " + (SafeGetValue("SCHEMA").Any() ? "\"" + SafeGetValue("SCHEMA") + "\"." : string.Empty) + "\"" + SafeGetValue("NAME") + "\"(\n" +
+                string.Join(",\n", columns.Select(s => s.CreateCommand()).ToArray()) +
+            "\n)";
+            return script;
+        }
+
+        public override CreateTableCommandDefinition Name(string name)
+        {
+            SetData("NAME", name);
+            return this;
+        }
+
+        public override CreateTableCommandDefinition Schema(string name)
+        {
+            SetData("SCHEMA", name);
+            return this;
+        }
+
+        private string SafeGetValue(string key)
+        {
+            if (!this.definitions.ContainsKey(key))
+                return string.Empty;
+            return this.definitions[key] ?? string.Empty;
+        }
+
+        public override CreateTableCommandDefinition Columns(ColumnCommandDefinition[] columns)
+        {
+            this.columns = columns;
+            return this;
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlDateTimeTypeDefinition.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlDateTimeTypeDefinition.cs
@@ -1,0 +1,12 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.PostgreSql.Infrastructure
+{
+    class PostgreSqlDateTimeTypeDefinition : ColumnTypeCommandDefinition
+    {
+        public override string CreateCommand()
+        {
+            return "TIMESTAMP";
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlHistoricalRepository.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlHistoricalRepository.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore;
+using NetHacksPack.Database.Extension.EF.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.PostgreSql.Infrastructure
+{
+    public delegate string MigrationTableNameProvider();
+
+    class PostgreSqlHistoricalRepository : IHistoricalRepository
+    {
+        private readonly DbContext dbContext;
+        private readonly MigrationTableNameProvider migrationTableNameProvider;
+
+        public PostgreSqlHistoricalRepository(DbContext dbContext, MigrationTableNameProvider migrationTableNameProvider)
+        {
+            this.dbContext = dbContext;
+            this.migrationTableNameProvider = migrationTableNameProvider;
+        }
+
+        public string GetInsertScript(string key, string value)
+        {
+            return "INSERT INTO " + migrationTableNameProvider() + $" VALUES ('{key}', '{value}')";
+        }
+
+        public bool HasEventLogTable(string migrationId)
+        {
+            return this.dbContext.Database.GetAppliedMigrations().Any(a => a == migrationId);
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlJsonTypeDefinition.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlJsonTypeDefinition.cs
@@ -1,0 +1,12 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.PostgreSql.Infrastructure
+{
+    class PostgreSqlJsonTypeDefinition : ColumnTypeCommandDefinition
+    {
+        public override string CreateCommand()
+        {
+            return "JSONB";
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlServerCommandGenerator.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlServerCommandGenerator.cs
@@ -1,0 +1,44 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+using System;
+using System.Text;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.PostgreSql.Infrastructure
+{
+    class PostgreSqlServerCommandGenerator : IDatabaseCommandGenerator
+    {
+        public ColumnCommandDefinition CreateColumn()
+        {
+            return new PostgreSqlColumnCommandDefinition();
+        }
+
+        public ColumnTypeCommandDefinition GetUniqueIdentifierColumn()
+        {
+            return new PostgreSqlUniquekeyTypeDefinition();
+        }
+
+        public CreateTableCommandDefinition GetCreateTableScript()
+        {
+            return new PostgreSqlCreateTableCommandDefinition();
+        }
+
+        public ColumnTypeCommandDefinition GetDateTimeColumn()
+        {
+            return new PostgreSqlDateTimeTypeDefinition();
+        }
+
+        public string GetInsertScript()
+        {
+            return "INSERT INTO {0} VALUES ({0})";
+        }
+
+        public ColumnTypeCommandDefinition GetJsonColumn()
+        {
+            return new PostgreSqlJsonTypeDefinition();
+        }
+
+        public ColumnTypeCommandDefinition GetVarcharColumn(int lenght)
+        {
+            return new PostgreSqlVarcharTypeDefinition(lenght);
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlUniquekeyTypeDefinition.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlUniquekeyTypeDefinition.cs
@@ -1,0 +1,12 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.PostgreSql.Infrastructure
+{
+    class PostgreSqlUniquekeyTypeDefinition : ColumnTypeCommandDefinition
+    {
+        public override string CreateCommand()
+        {
+            return "UUID";
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlVarcharTypeDefinition.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Loggin.PostgreSql/Infrastructure/PostgreSqlVarcharTypeDefinition.cs
@@ -1,0 +1,18 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.PostgreSql.Infrastructure
+{
+    class PostgreSqlVarcharTypeDefinition : ColumnTypeCommandDefinition
+    {
+        private readonly int lenght;
+
+        public PostgreSqlVarcharTypeDefinition(int lenght)
+        {
+            this.lenght = lenght;
+        }
+        public override string CreateCommand()
+        {
+            return $"VARCHAR({lenght})";
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Configuration/SqlEventLogConfiguration.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Configuration/SqlEventLogConfiguration.cs
@@ -10,9 +10,16 @@ namespace NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer.Configuratio
 {
     internal class SqlEventLogConfiguration : EventsLogsConfiguration
     {
+        private readonly string tableName;
+
+        public SqlEventLogConfiguration(string tableName)
+        {
+            this.tableName = tableName;
+        }
+
         public override void Configure(EntityTypeBuilder<EventLog> builder)
         {
-            builder.ToTable("EventsLogs");
+            builder.ToTable(tableName);
 
             builder.HasKey(p => p.Id);
 
@@ -34,10 +41,10 @@ namespace NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer.Configuratio
                 .HasColumnType("VARCHAR(50)");
             builder
                 .Property(p => p.DataKeysValues)
-                .HasColumnType("JSON");
+                .HasColumnType("NVARCHAR(MAX)");
             builder
                 .Property(p => p.OriginalValues)
-                .HasColumnType("JSON");
+                .HasColumnType("NVARCHAR(MAX)");
         }
     }
 }

--- a/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/DependencyInjection/DatabaseInfrastructureDependenciesInjector.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/DependencyInjection/DatabaseInfrastructureDependenciesInjector.cs
@@ -1,19 +1,29 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using NetHacksPack.Database.Extension.EF.Infrastructure;
 using NetHacksPack.Database.Extension.EFCore.Logging.DependencyInjection;
+using NetHacksPack.Database.Extension.EFCore.Logging.Providers;
 using NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer.Configuration;
+using NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer.Infrastructure;
 
 namespace NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer.DependencyInjection
 {
     public static class DatabaseInfrastructureDependenciesInjector
     {
-        public static LoggerExtensionBuilder AddLoggingExtensionForEFSqlServer<TDbContext>(this IServiceCollection services, UserProvider userProvider)
+        public static LoggerExtensionBuilder AddLoggingExtensionForEFSqlServer<TDbContext>(this IServiceCollection services, string tableName, UserProvider userProvider, string migrationTableName, string schemma = null)
             where TDbContext : DbContext
         {
-            return services.AddLoggingExtensionForEF<TDbContext>(userProvider, (services) =>
-           {
-               return new SqlEventLogConfiguration();
-           });
+            
+            services.AddScoped<IDatabaseCommandGenerator, SqlServerCommandGenerator>();
+            services.AddScoped<IHistoricalRepository, SqlHistoricalRepository>();
+            services.AddSingleton<SchemmaNameProvider>(() => (schemma?.Length > 0 ? schemma : string.Empty));
+            services.AddSingleton<MigrationTableNameProvider>(() => {
+                return (schemma?.Length > 0 ? "[" + schemma + "]." : string.Empty) + "[" + migrationTableName + "]";
+            });
+            return services.AddLoggingExtensionForEF<TDbContext>(tableName, userProvider, (services) =>
+            {
+                return new SqlEventLogConfiguration(tableName);
+            });
         }
     }
 }

--- a/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlColumnCommandDefinition.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlColumnCommandDefinition.cs
@@ -1,0 +1,66 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+using NetHacksPack.Database.Extension.EF.Infrastructure.Exceptions;
+using System.Collections.Generic;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer.Infrastructure
+{
+    class SqlColumnCommandDefinition : ColumnCommandDefinition
+    {
+        private Dictionary<string, string> definitions = new Dictionary<string, string>(3);
+
+        private void SetData(string key, string value)
+        {
+            if (!definitions.ContainsKey(key))
+                definitions.Add(key, string.Empty);
+            definitions[key] = value;
+        }
+
+        public override ColumnCommandDefinition HasType(ColumnTypeCommandDefinition type)
+        {
+            this.SetData("TYPE", type.CreateCommand());
+            return this;
+        }
+
+        public override ColumnCommandDefinition IsNotNull()
+        {
+            this.SetData("NULL", "IS NOT NULL");
+            return this;
+        }
+
+        public override ColumnCommandDefinition IsNull()
+        {
+            this.SetData("NULL", "IS NULL");
+            return this;
+        }
+
+        public override ColumnCommandDefinition Name(string name)
+        {
+            this.SetData("NAME", name);
+            return this;
+        }
+
+        public override ColumnCommandDefinition PrimaryKey()
+        {
+            SetData("PK", "NOT NULL PRIMARY KEY");
+            return this;
+        }
+
+        public override string CreateCommand()
+        {
+            if (!this.definitions.ContainsKey("NAME"))
+                throw new InvalidSintaxException("invalid column name, a column name must be informed to create a column");
+            if(!this.definitions.ContainsKey("TYPE"))
+                throw new InvalidSintaxException("invalid column type, a column type must be informed to create a column");
+            return string.Join(" ", SafeGetValue("NAME"), SafeGetValue("TYPE"), SafeGetValue("NULL"), SafeGetValue("PK")).TrimEnd();
+        }
+
+        private string SafeGetValue(string key)
+        {
+            if (!this.definitions.ContainsKey(key))
+                return string.Empty;
+            return this.definitions[key] ?? string.Empty;
+        }
+    }
+
+
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlCreateTableCommandDefinition.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlCreateTableCommandDefinition.cs
@@ -1,0 +1,59 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+using NetHacksPack.Database.Extension.EF.Infrastructure.Exceptions;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer.Infrastructure
+{
+    class SqlCreateTableCommandDefinition : CreateTableCommandDefinition
+    {
+        private Dictionary<string, string> definitions = new Dictionary<string, string>(3);
+        private ColumnCommandDefinition[] columns = null;
+
+        private void SetData(string key, string value)
+        {
+            if (!definitions.ContainsKey(key))
+                definitions.Add(key, string.Empty);
+            definitions[key] = value;
+        }
+
+        public override string CreateCommand()
+        {
+            if (!this.definitions.ContainsKey("NAME"))
+                throw new InvalidSintaxException("invalid table name, a table name must be informed to create a table");
+            if(columns == null || columns.Length == 0)
+                throw new InvalidSintaxException("invalid columns definitions, a set of columns must be informed to create a table");
+
+            return "CREATE TABLE " + (SafeGetValue("SCHEMA").Any() ? "[" + SafeGetValue("SCHEMA") + "]." : string.Empty) + "[" + SafeGetValue("NAME") + "](\n" +
+                string.Join(",\n", columns.Select(s => s.CreateCommand()).ToArray()) +
+            ")";
+        }
+
+        public override CreateTableCommandDefinition Name(string name)
+        {
+            SetData("NAME", name);
+            return this;
+        }
+
+        public override CreateTableCommandDefinition Schema(string name)
+        {
+            SetData("SCHEMA", name);
+            return this;
+        }
+
+        private string SafeGetValue(string key)
+        {
+            if (!this.definitions.ContainsKey(key))
+                return string.Empty;
+            return this.definitions[key] ?? string.Empty;
+        }
+
+        public override CreateTableCommandDefinition Columns(ColumnCommandDefinition[] columns)
+        {
+            this.columns = columns;
+            return this;
+        }
+    }
+
+
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlDateTimeTypeDefinition.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlDateTimeTypeDefinition.cs
@@ -1,0 +1,14 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer.Infrastructure
+{
+    class SqlDateTimeTypeDefinition : ColumnTypeCommandDefinition
+    {
+        public override string CreateCommand()
+        {
+            return "DATETIME";
+        }
+    }
+
+
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlHistoricalRepository.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlHistoricalRepository.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore;
+using NetHacksPack.Database.Extension.EF.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer.Infrastructure
+{
+    public delegate string MigrationTableNameProvider();
+
+    class SqlHistoricalRepository : IHistoricalRepository
+    {
+        private readonly DbContext dbContext;
+        private readonly MigrationTableNameProvider migrationTableNameProvider;
+
+        public SqlHistoricalRepository(DbContext dbContext, MigrationTableNameProvider migrationTableNameProvider)
+        {
+            this.dbContext = dbContext;
+            this.migrationTableNameProvider = migrationTableNameProvider;
+        }
+
+        public string GetInsertScript(string key, string value)
+        {
+            return "INSERT INTO " + migrationTableNameProvider() + $" VALUES ('{key}', '{value}')";
+        }
+
+        public bool HasEventLogTable(string migrationId)
+        {
+            var cnn = this.dbContext.Database.GetDbConnection();
+            cnn.Open();
+            var cmd = cnn.CreateCommand();
+            cmd.CommandText = $"if(object_id('{migrationId}') is not null) select 1";
+            var reader = cmd.ExecuteReader();
+            var result = reader.HasRows;
+            reader.Close();
+            cnn.Close();
+            return result;
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlJsonTypeDefinition.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlJsonTypeDefinition.cs
@@ -1,0 +1,12 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer.Infrastructure
+{
+    class SqlJsonTypeDefinition : ColumnTypeCommandDefinition
+    {
+        public override string CreateCommand()
+        {
+            return "NVARCHAR(MAX)";
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlServerCommandGenerator.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlServerCommandGenerator.cs
@@ -1,0 +1,44 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+using System;
+using System.Text;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer.Infrastructure
+{
+    class SqlServerCommandGenerator : IDatabaseCommandGenerator
+    {
+        public ColumnCommandDefinition CreateColumn()
+        {
+            return new SqlColumnCommandDefinition();
+        }
+
+        public ColumnTypeCommandDefinition GetUniqueIdentifierColumn()
+        {
+            return new SqlUniquekeyTypeDefinition();
+        }
+
+        public CreateTableCommandDefinition GetCreateTableScript()
+        {
+            return new SqlCreateTableCommandDefinition();
+        }
+
+        public ColumnTypeCommandDefinition GetDateTimeColumn()
+        {
+            return new SqlDateTimeTypeDefinition();
+        }
+
+        public string GetInsertScript()
+        {
+            return "INSERT INTO {0} VALUES ({0})";
+        }
+
+        public ColumnTypeCommandDefinition GetJsonColumn()
+        {
+            return new SqlJsonTypeDefinition();
+        }
+
+        public ColumnTypeCommandDefinition GetVarcharColumn(int lenght)
+        {
+            return new SqlVarcharTypeDefinition(lenght);
+        }
+    }
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlUniquekeyTypeDefinition.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlUniquekeyTypeDefinition.cs
@@ -1,0 +1,14 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer.Infrastructure
+{
+    class SqlUniquekeyTypeDefinition : ColumnTypeCommandDefinition
+    {
+        public override string CreateCommand()
+        {
+            return "UNIQUEIDENTIFIER";
+        }
+    }
+
+
+}

--- a/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlVarcharTypeDefinition.cs
+++ b/src/NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer/Infrastructure/SqlVarcharTypeDefinition.cs
@@ -1,0 +1,20 @@
+﻿using NetHacksPack.Database.Extension.EF.Infrastructure;
+
+namespace NetHacksPack.Database.Extensions.EFCore.Logging.SqlServer.Infrastructure
+{
+    class SqlVarcharTypeDefinition : ColumnTypeCommandDefinition
+    {
+        private readonly int lenght;
+
+        public SqlVarcharTypeDefinition(int lenght)
+        {
+            this.lenght = lenght;
+        }
+        public override string CreateCommand()
+        {
+            return $"VARCHAR({lenght})";
+        }
+    }
+
+
+}


### PR DESCRIPTION
updated audit feature in order to support multiple providers without depending directly from migration feature.

so the projects were refactored to provide classes that can build the database create table

a bug where non attached objects were not tracked by the audit package was fixed too